### PR TITLE
Support comparing nil versions

### DIFF
--- a/version.go
+++ b/version.go
@@ -68,7 +68,18 @@ func (v *buildlessVersion) write(b *strings.Builder) {
 //
 // If v has higher precedence than other, 1 is returned. If other has higher
 // precedence, -1 is returned. If the two versions are equal, zero is returned.
+// A nil Version has lower precedence than a non-nil version. Two nil versions
+// have the same precedence.
 func (v *Version) Compare(other *Version) int {
+	switch {
+	case v == nil && other == nil:
+		return 0
+	case v == nil:
+		return -1
+	case other == nil:
+		return 1
+	}
+
 	cmp := v.compareNonPre(other)
 	if cmp == 0 {
 		cmp = v.comparePre(other)

--- a/version_test.go
+++ b/version_test.go
@@ -162,3 +162,22 @@ func TestCompare(t *testing.T) {
 		})
 	}
 }
+func TestCompare_nil(t *testing.T) {
+	var nv *semver.Version
+	v, err := semver.Parse("0.0.0")
+	if err != nil {
+		t.Fatal("got error parsing test version")
+	}
+
+	if nv.Compare(v) != -1 {
+		t.Errorf("nil version not less than other version")
+	}
+
+	if v.Compare(nv) != 1 {
+		t.Errorf("other version not greater than nil version")
+	}
+
+	if nv.Compare(nv) != 0 {
+		t.Errorf("two nil versions are not equal")
+	}
+}


### PR DESCRIPTION
If parsing a semver fails, and you're only doing comparisons, you can still
compare nil versions.  A nil version is less than a non-nil version.
